### PR TITLE
Add 2s staged fade-up entrance animation for Home choreo sections

### DIFF
--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/HomeScreen.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -38,6 +39,7 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -47,6 +49,8 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -68,6 +72,11 @@ import kotlin.random.Random
 
 private const val HOME_PROMO_VIDEO_ASSET = "home_intro.mp4"
 private const val HOME_PROMO_COLLAPSE_DURATION_MS = 560 // 카드가 위로 올라오는 속도는 이 값으로 조절
+private const val HOME_SECTION_ENTRANCE_TOTAL_DURATION_MS = 2000
+private const val HOME_SECTION_ENTRANCE_FINISH_DURATION_MS = 1500
+private const val HOME_SECTION_ENTRANCE_FAST_DURATION_MS =
+    HOME_SECTION_ENTRANCE_TOTAL_DURATION_MS - HOME_SECTION_ENTRANCE_FINISH_DURATION_MS
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
@@ -179,23 +188,35 @@ fun HomeScreen(
             }
 
             item {
-                RecentChoreoSection(
-                    recentChoreo = recentChoreo,
-                    onSongClick = onSongClick
-                )
+                HomeSectionEntrance(
+                    initialOffsetY = 120.dp
+                ) {
+                    RecentChoreoSection(
+                        recentChoreo = recentChoreo,
+                        onSongClick = onSongClick
+                    )
+                }
             }
 
             item {
-                RegisteredChoreoSection(
-                    dbSongs = dbSongs,
-                    onSongClick = onSongClick
-                )
+                HomeSectionEntrance(
+                    initialOffsetY = 260.dp
+                ) {
+                    RegisteredChoreoSection(
+                        dbSongs = dbSongs,
+                        onSongClick = onSongClick
+                    )
+                }
             }
 
             item {
-                TodayRecommendedSection(
-                    onSongClick = onSongClick
-                )
+                HomeSectionEntrance(
+                    initialOffsetY = 300.dp
+                ) {
+                    TodayRecommendedSection(
+                        onSongClick = onSongClick
+                    )
+                }
             }
         }
 
@@ -257,6 +278,65 @@ fun HomeScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun HomeSectionEntrance(
+    initialOffsetY: Dp,
+    content: @Composable () -> Unit
+) {
+    val density = LocalDensity.current
+    val initialOffsetPx = with(density) { initialOffsetY.toPx() }
+    val translateY = remember(initialOffsetPx) { Animatable(initialOffsetPx) }
+    val alpha = remember { Animatable(0f) }
+
+    LaunchedEffect(initialOffsetPx) {
+        translateY.snapTo(initialOffsetPx)
+        alpha.snapTo(0f)
+
+        // 0.5초: 빠르게 위로 올라오고, 1.5초: 천천히 자리 잡는 2단계 모션
+        launch {
+            translateY.animateTo(
+                targetValue = initialOffsetPx * 0.2f,
+                animationSpec = tween(
+                    durationMillis = HOME_SECTION_ENTRANCE_FAST_DURATION_MS,
+                    easing = LinearEasing
+                )
+            )
+            translateY.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(
+                    durationMillis = HOME_SECTION_ENTRANCE_FINISH_DURATION_MS,
+                    easing = FastOutSlowInEasing
+                )
+            )
+        }
+
+        launch {
+            alpha.animateTo(
+                targetValue = 0.8f,
+                animationSpec = tween(
+                    durationMillis = HOME_SECTION_ENTRANCE_FAST_DURATION_MS,
+                    easing = LinearEasing
+                )
+            )
+            alpha.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(
+                    durationMillis = HOME_SECTION_ENTRANCE_FINISH_DURATION_MS,
+                    easing = FastOutSlowInEasing
+                )
+            )
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .offset { IntOffset(0, translateY.value.toInt()) }
+            .graphicsLayer { this.alpha = alpha.value }
+    ) {
+        content()
     }
 }
 


### PR DESCRIPTION
### Motivation
- 홈 화면의 `최근 연습한 안무`, `등록된 안무 목록`, `오늘의 추천 안무` 섹션이 진입 시 바로 보여지는 대신 요청한 대로 페이드 인과 위로 올라오는 모션(초반 빠르고 이후 천천히 마무리)을 갖도록 하기 위함입니다.
- 모션은 총 2초이며 그중 1.5초를 천천히 마무리하는 2단계 타이밍(빠른 단계 + 느린 단계)으로 구성해야 합니다.

### Description
- `HomeScreen.kt`에 재사용 가능한 `HomeSectionEntrance` 컴포저블을 추가하여 섹션 진입 시 `alpha`와 `translateY`를 애니메이션하도록 구현했습니다.
- 애니메이션 타이밍 상수 `HOME_SECTION_ENTRANCE_TOTAL_DURATION_MS`, `HOME_SECTION_ENTRANCE_FINISH_DURATION_MS`, `HOME_SECTION_ENTRANCE_FAST_DURATION_MS`를 추가하고 총 2000ms, 마무리 1500ms로 설정했습니다.
- 이징은 초반 빠른 이동에 `LinearEasing`을 사용하고 마무리에는 `FastOutSlowInEasing`을 사용하여 자연스럽게 감속되도록 했습니다.
- 기존의 `RecentChoreoSection`, `RegisteredChoreoSection`, `TodayRecommendedSection` 호출부를 `HomeSectionEntrance`로 래핑하고 각각 초기 오프셋을 `120.dp`, `260.dp`, `300.dp`로 설정해 화면 중간/하단에서 올라오는 연출을 적용했습니다.
- 필요한 Compose import(`LinearEasing`, `IntOffset`, `Dp`, `LocalDensity`)를 추가했습니다.

### Testing
- 시도한 자동화 빌드: `./gradlew :kpop-android-app:app:compileDebugKotlin` 실패(레포트 루트에 `gradlew` 없음). ❌
- 시도한 자동화 빌드: `./gradlew :app:compileDebugKotlin` 실패(권한 문제로 실행 불가), 이후 `chmod +x gradlew` 후 실행했으나 Gradle 배포 파일 다운로드가 프록시로 차단되어 빌드 검증 불가(HTTP 403). ❌
- 소스 변경은 로컬에서 수정 및 커밋되었으며(파일: `kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/HomeScreen.kt`), 빌드 검증은 네트워크/환경 제약으로 수행되지 않았습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ab6124b4832dae5b5b8cece8fbc1)