### PR TITLE
Use PracticeScreenTablet on tablets and update recording navigation

### DIFF
--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/AppNavigation.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/AppNavigation.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -1056,25 +1057,48 @@ fun AppNavHost(
             val length = backStackEntry.arguments?.getString("length")?.let { Screen.decodeArg(it) } ?: ""
             val videoUrl = backStackEntry.arguments?.getString("videoUrl")?.let { Screen.decodeArg(it) } ?: ""
 
-            PracticeScreenMobile(
-                songId = songId,
-                songTitle = songTitle,
-                artistPart = artistPart,
-                difficulty = difficulty,
-                length = length,
-                videoUrl = videoUrl,
-                onBackClick = { navController.popBackStack() },
-                onRecordClick = {
-                    val encodedTitle = Screen.encodeArg(songTitle)
-                    val encodedArtistPart = Screen.encodeArg(artistPart)
-                    val encodedDifficulty = Screen.encodeArg(difficulty)
-                    val encodedUrl = Screen.encodeArg(videoUrl) // 💡 전달받은 URL을 RecordScreen으로 다시 패스!
-                    navController.navigate("record/$songId/$encodedTitle/$encodedArtistPart/$encodedDifficulty/$encodedUrl") {
-                        popUpTo(Screen.DancePractice.route) { inclusive = true }
+            val configuration = LocalConfiguration.current
+            val isTablet = configuration.smallestScreenWidthDp >= 600
+
+            if (isTablet) {
+                PracticeScreenTablet(
+                    songTitle = songTitle,
+                    artistPart = artistPart,
+                    difficulty = difficulty,
+                    length = length,
+                    onBackClick = { navController.popBackStack() },
+                    onSettingsClick = { navController.navigate(Screen.PracticeSettings.route) },
+                    onRecordingComplete = { resultString ->
+                        val jsonFileName = resultString.split("/").last()
+                        val encodedJson = Screen.encodeArg(jsonFileName)
+                        val encodedVideo = Screen.encodeArg(resultString)
+
+                        navController.navigate("practiceResult/$encodedJson/$encodedVideo") {
+                            popUpTo(Screen.DancePractice.route) { inclusive = true }
+                        }
                     }
-                },
-                onSettingsClick = { navController.navigate(Screen.PracticeSettings.route) }
-            )
+                )
+            } else {
+                PracticeScreenMobile(
+                    songId = songId,
+                    songTitle = songTitle,
+                    artistPart = artistPart,
+                    difficulty = difficulty,
+                    length = length,
+                    videoUrl = videoUrl,
+                    onBackClick = { navController.popBackStack() },
+                    onRecordClick = {
+                        val encodedTitle = Screen.encodeArg(songTitle)
+                        val encodedArtistPart = Screen.encodeArg(artistPart)
+                        val encodedDifficulty = Screen.encodeArg(difficulty)
+                        val encodedUrl = Screen.encodeArg(videoUrl) // 💡 전달받은 URL을 RecordScreen으로 다시 패스!
+                        navController.navigate("record/$songId/$encodedTitle/$encodedArtistPart/$encodedDifficulty/$encodedUrl") {
+                            popUpTo(Screen.DancePractice.route) { inclusive = true }
+                        }
+                    },
+                    onSettingsClick = { navController.navigate(Screen.PracticeSettings.route) }
+                )
+            }
         }
         composable(Screen.AnalysisLoading.route) {
             AnalysisWaitingScreen(


### PR DESCRIPTION
### Motivation
- Add device-size aware navigation so tablet devices show a tablet-optimized practice UI (`PracticeScreenTablet`) instead of the mobile screen.
- Preserve existing mobile navigation and recording flow while adapting the tablet flow to return encoded recording results for the `PracticeResult` screen.
- Ensure recording completion on tablet encodes and routes the resulting JSON and video path consistently with the rest of the app.

### Description
- Import `LocalConfiguration` and use `configuration.smallestScreenWidthDp >= 600` to detect tablets and set an `isTablet` flag.
- Conditionally show `PracticeScreenTablet` when `isTablet` is true, otherwise show `PracticeScreenMobile` as before.
- Implement `onRecordingComplete` for tablet to extract the JSON filename from the result string, encode arguments via `Screen.encodeArg`, and navigate to the `practiceResult` route with `popUpTo(Screen.DancePractice.route) { inclusive = true }`.
- Preserve existing mobile behavior including `onRecordClick`, argument encoding, and navigation to the `record` route, and keep `onSettingsClick` handlers wired.

### Testing
- Built debug APK with `./gradlew assembleDebug`, and the build completed successfully.
- No automated unit or instrumentation tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed4d332d48320a913846e264f5d11)