### PR TITLE
Implement tablet split practice recording (left expert video + right CameraX recording with 3s countdown)

### DIFF
--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/AppNavigation.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/AppNavigation.kt
@@ -1062,16 +1062,23 @@ fun AppNavHost(
 
             if (isTablet) {
                 PracticeScreenTablet(
+                    songId = songId,
                     songTitle = songTitle,
                     artistPart = artistPart,
                     difficulty = difficulty,
                     length = length,
+                    videoUrl = videoUrl,
                     onBackClick = { navController.popBackStack() },
                     onSettingsClick = { navController.navigate(Screen.PracticeSettings.route) },
+                    onNavigateHome = { navController.popBackStack(Screen.Home.route, false) },
+                    mainViewModel = viewModel,
                     onRecordingComplete = { resultString ->
-                        val jsonFileName = resultString.split("/").last()
+                        val dataParts = resultString.split("|")
+                        val rawPath = dataParts[0]
+                        val videoUriString = if (dataParts.size > 1) dataParts[1] else ""
+                        val jsonFileName = rawPath.split("/").last()
                         val encodedJson = Screen.encodeArg(jsonFileName)
-                        val encodedVideo = Screen.encodeArg(resultString)
+                        val encodedVideo = Screen.encodeArg(videoUriString)
 
                         navController.navigate("practiceResult/$encodedJson/$encodedVideo") {
                             popUpTo(Screen.DancePractice.route) { inclusive = true }

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/PracticeScreenTablet.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/PracticeScreenTablet.kt
@@ -3,14 +3,23 @@ package com.example.kpopdancepracticeai.ui
 import android.Manifest
 import android.content.ContentValues
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.provider.MediaStore
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.camera.core.*
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.Preview
 import androidx.camera.lifecycle.ProcessCameraProvider
-import androidx.camera.video.*
+import androidx.camera.video.FallbackStrategy
+import androidx.camera.video.MediaStoreOutputOptions
+import androidx.camera.video.Quality
+import androidx.camera.video.QualitySelector
+import androidx.camera.video.Recorder
+import androidx.camera.video.Recording
+import androidx.camera.video.VideoCapture
+import androidx.camera.video.VideoRecordEvent
 import androidx.camera.view.PreviewView
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateDpAsState
@@ -22,51 +31,130 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview as ComposePreview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
 import com.example.kpopdancepracticeai.data.PresignedUrlUploader
-import com.example.kpopdancepracticeai.util.NetworkUtils
+import com.example.kpopdancepracticeai.data.dto.AnalysisResultResponse
+import com.example.kpopdancepracticeai.data.entity.User
+import com.example.kpopdancepracticeai.data.mapper.AnalysisMapper
+import com.example.kpopdancepracticeai.data.repository.AuthRepository
 import com.example.kpopdancepracticeai.ui.theme.KpopDancePracticeAITheme
+import com.example.kpopdancepracticeai.util.FilenameParser
+import com.example.kpopdancepracticeai.util.NetworkUtils
+import com.example.kpopdancepracticeai.viewmodel.MainViewModel
 import com.example.kpopdancepracticeai.viewmodel.SettingsViewModel
+import com.google.gson.Gson
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import java.io.File
+import java.net.URLDecoder
 import java.util.Locale
+
+private const val TabletRecordCountdownSeconds = 3
+
+private fun extractTabletExpertIdentifier(
+    expertVideoUrl: String,
+    songTitle: String,
+    artist: String,
+    part: String
+): String {
+    val fromUrl = expertVideoUrl
+        .substringBefore("?")
+        .let { raw ->
+            val parsed = Uri.parse(raw).lastPathSegment ?: raw.substringAfterLast("/")
+            runCatching { URLDecoder.decode(parsed, "UTF-8") }.getOrDefault(parsed)
+        }
+        .substringBeforeLast(".")
+        .trim()
+        .takeIf { it.isNotBlank() }
+
+    if (fromUrl != null) return fromUrl
+
+    val songToken = songTitle.replace(" ", "").replace("_", "")
+    val artistToken = artist
+        .substringAfter("(")
+        .substringBefore(")")
+        .ifBlank { artist }
+        .replace(" ", "")
+        .replace("_", "")
+    val partToken = part.filter { it.isDigit() }.ifEmpty { "0" }
+    return "${songToken}_${artistToken}_${partToken}"
+}
 
 @Composable
 fun PracticeScreenTablet(
+    songId: Long = 0L,
     songTitle: String = "Dynamite",
     artistPart: String = "BTS · Part 2: 메인 파트",
     difficulty: String = "보통",
     length: String = "2:15",
+    videoUrl: String = "",
     onBackClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
+    onNavigateHome: () -> Unit = onBackClick,
     onRecordingComplete: (String) -> Unit = {},
+    mainViewModel: MainViewModel? = null,
     settingsViewModel: SettingsViewModel = viewModel()
 ) {
     val context = LocalContext.current
@@ -75,12 +163,16 @@ fun PracticeScreenTablet(
     val scope = rememberCoroutineScope()
     val isPreview = LocalInspectionMode.current
     val uploader = remember { PresignedUrlUploader(context) }
+    val userProfile by mainViewModel?.currentUserProfile?.collectAsStateWithLifecycle() ?: remember { mutableStateOf<User?>(null) }
+    val authUserId = remember { AuthRepository(context).getCurrentUser()?.uid }
+    val artistAndPart = remember(artistPart) { artistPart.split("·").map { it.trim() } }
+    val artist = artistAndPart.getOrNull(0) ?: "Unknown"
+    val part = artistAndPart.getOrNull(1) ?: artistPart
 
-    // 권한 상태 관리
     var hasPermissions by remember {
         mutableStateOf(
             if (isPreview) true else
-            ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED &&
+                ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED &&
                     ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
         )
     }
@@ -96,26 +188,90 @@ fun PracticeScreenTablet(
         }
     }
 
-    // CameraX 상태
     val videoCaptureState = remember { mutableStateOf<VideoCapture<Recorder>?>(null) }
     val recordingState = remember { mutableStateOf<Recording?>(null) }
     var isRecording by remember { mutableStateOf(false) }
+    var isCountdownVisible by remember { mutableStateOf(false) }
+    var countdownNumber by remember { mutableIntStateOf(0) }
     var recordingTime by remember { mutableIntStateOf(0) }
     var lensFacing by remember { mutableIntStateOf(CameraSelector.LENS_FACING_FRONT) }
+    var areControlsVisible by remember { mutableStateOf(true) }
+    var selectedSpeed by remember { mutableFloatStateOf(1.0f) }
+    var isMuted by remember { mutableStateOf(false) }
+    var currentPositionMs by remember { mutableLongStateOf(0L) }
+    var totalDurationMs by remember { mutableLongStateOf(0L) }
+    var showAnalysisLoading by remember { mutableStateOf(false) }
+    var analysisProgress by remember { mutableFloatStateOf(0f) }
+    var analysisStatusMessage by remember { mutableStateOf("업로드 준비 중...") }
+    var hasAutoStoppedRecording by remember { mutableStateOf(false) }
+    var progressRampJob by remember { mutableStateOf<Job?>(null) }
 
     LaunchedEffect(settings.isFrontCamera) {
         lensFacing = if (settings.isFrontCamera) CameraSelector.LENS_FACING_FRONT else CameraSelector.LENS_FACING_BACK
     }
 
-    // UI 상태
-    var currentPosition by remember { mutableStateOf(0.1f) }
-    var selectedSpeed by remember { mutableStateOf(1.0f) }
-    var areControlsVisible by remember { mutableStateOf(true) }
+    val exoPlayer = remember { ExoPlayer.Builder(context).build() }
+
+    DisposableEffect(Unit) {
+        onDispose { exoPlayer.release() }
+    }
+
+    LaunchedEffect(videoUrl) {
+        if (videoUrl.isBlank()) return@LaunchedEffect
+
+        val finalUrl = if (!videoUrl.startsWith("asset:///")) {
+            videoUrl.replace("file:///android_asset/", "asset:///")
+        } else {
+            videoUrl
+        }
+
+        try {
+            exoPlayer.setMediaItem(MediaItem.fromUri(Uri.parse(finalUrl)))
+            exoPlayer.repeatMode = Player.REPEAT_MODE_OFF
+            exoPlayer.prepare()
+            exoPlayer.seekTo(0)
+            exoPlayer.playWhenReady = false
+        } catch (e: Exception) {
+            Log.e("PracticeTablet", "영상 로드 실패: $finalUrl", e)
+        }
+    }
+
+    LaunchedEffect(selectedSpeed) {
+        exoPlayer.setPlaybackSpeed(selectedSpeed)
+    }
+
+    LaunchedEffect(isMuted) {
+        exoPlayer.volume = if (isMuted) 0f else 1f
+    }
+
+    LaunchedEffect(Unit) {
+        while (true) {
+            currentPositionMs = exoPlayer.currentPosition
+            totalDurationMs = if (exoPlayer.duration > 0) exoPlayer.duration else 0L
+            delay(100)
+        }
+    }
+
+    DisposableEffect(exoPlayer, isRecording) {
+        val playbackListener = object : Player.Listener {
+            override fun onPlaybackStateChanged(playbackState: Int) {
+                if (playbackState == Player.STATE_ENDED && isRecording && !hasAutoStoppedRecording) {
+                    hasAutoStoppedRecording = true
+                    recordingState.value?.stop()
+                    recordingState.value = null
+                    isRecording = false
+                }
+            }
+        }
+
+        exoPlayer.addListener(playbackListener)
+        onDispose { exoPlayer.removeListener(playbackListener) }
+    }
 
     LaunchedEffect(isRecording) {
         if (isRecording) {
             while (isRecording) {
-                kotlinx.coroutines.delay(1000)
+                delay(1000)
                 recordingTime++
             }
         } else {
@@ -123,132 +279,259 @@ fun PracticeScreenTablet(
         }
     }
 
-    // 녹화 토글 함수 (중앙 버튼 및 하단 버튼 공용)
-    val toggleRecording = {
-        if (isRecording) {
-            recordingState.value?.stop()
-            recordingState.value = null
+    fun handleRecordingFinalize(recordEvent: VideoRecordEvent.Finalize) {
+        exoPlayer.pause()
+
+        if (recordEvent.hasError()) {
+            recordingState.value?.close()
             isRecording = false
-        } else {
-            val videoCapture = videoCaptureState.value
-            if (videoCapture != null) {
-                isRecording = true
-                val name = "Kpop_Tablet_${System.currentTimeMillis()}.mp4"
-                val contentValues = ContentValues().apply {
-                    put(MediaStore.MediaColumns.DISPLAY_NAME, name)
-                    put(MediaStore.MediaColumns.MIME_TYPE, "video/mp4")
-                    put(MediaStore.Video.Media.RELATIVE_PATH, "Movies/KpopDancePractice")
-                }
-                val mediaStoreOutputOptions = MediaStoreOutputOptions
-                    .Builder(context.contentResolver, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
-                    .setContentValues(contentValues)
-                    .build()
+            Toast.makeText(context, "녹화 저장 실패: ${recordEvent.error}", Toast.LENGTH_LONG).show()
+            return
+        }
 
-                recordingState.value = videoCapture.output
-                    .prepareRecording(context, mediaStoreOutputOptions)
-                    .withAudioEnabled()
-                    .start(ContextCompat.getMainExecutor(context)) { event ->
-                        if (event is VideoRecordEvent.Finalize) {
-                            if (!event.hasError()) {
-                                val uri = event.outputResults.outputUri
-                                
-                                // [파일명 형식 생성] RecordScreenMobile.kt와 동일
-                                val userId = "xooyong"
-                                val songIdClean = songTitle.replace(" ", "").replace("_", "")
-                                
-                                // artistPart 파싱: "BTS · Part 2: 메인 파트"
-                                val parts = artistPart.split("·")
-                                val partInfo = parts.getOrNull(1)?.trim() ?: artistPart
-                                val partNum = partInfo.filter { it.isDigit() }.ifEmpty { "0" }
-                                val partName = partInfo.split(":").lastOrNull()?.replace(" ", "")?.replace("_", "") ?: "None"
-                                val timestamp = System.currentTimeMillis()
+        val uri = recordEvent.outputResults.outputUri
+        val userId = userProfile?.userUuid ?: authUserId ?: "none"
+        val expertIdentifier = extractTabletExpertIdentifier(videoUrl, songTitle, artist, part)
+        val partNum = expertIdentifier.substringAfterLast("_", "0").ifBlank { "0" }
+        val partNumberForDb = partNum.toIntOrNull() ?: 0
+        val timestamp = System.currentTimeMillis()
+        val filename = "${userId}_${expertIdentifier}_${timestamp}.mp4"
+        val songIdForDbLong = if (songId > 0L) songId else (expertIdentifier.substringBefore("_").toLongOrNull() ?: 0L)
+        val songIdForDb = songIdForDbLong.toString()
 
-                                val filename = "${userId}_${songIdClean}_${partNum}_${partName}_${timestamp}.mp4"
+        scope.launch {
+            if (!settings.isServerUploadEnabled) {
+                Toast.makeText(context, "서버 전송 동의가 꺼져 있어 로컬에 저장합니다.", Toast.LENGTH_SHORT).show()
+                mainViewModel?.markPracticePartCompleted(userId, songIdForDbLong, partNumberForDb, artist)
+                onNavigateHome()
+                return@launch
+            }
 
-                                scope.launch {
-                                    if (!settings.isServerUploadEnabled) {
-                                        Toast.makeText(context, "서버 전송 동의가 꺼져 있어 로컬에 저장합니다.", Toast.LENGTH_SHORT).show()
-                                        return@launch
-                                    }
+            if (!settings.isAutoUpload) {
+                Toast.makeText(context, "자동 전송이 꺼져 있어 로컬에 저장합니다.", Toast.LENGTH_SHORT).show()
+                mainViewModel?.markPracticePartCompleted(userId, songIdForDbLong, partNumberForDb, artist)
+                onNavigateHome()
+                return@launch
+            }
 
-                                    if (!settings.isAutoUpload) {
-                                        Toast.makeText(context, "자동 전송이 꺼져 있어 로컬에 저장합니다.", Toast.LENGTH_SHORT).show()
-                                        return@launch
-                                    }
+            if (settings.isWifiOnlyUpload && !NetworkUtils.isWifiConnected(context)) {
+                Toast.makeText(context, "WIFI 전용 업로드 설정으로 로컬 저장 후 홈으로 이동합니다.", Toast.LENGTH_SHORT).show()
+                mainViewModel?.markPracticePartCompleted(userId, songIdForDbLong, partNumberForDb, artist)
+                onNavigateHome()
+                return@launch
+            }
 
-                                    if (settings.isWifiOnlyUpload && !NetworkUtils.isWifiConnected(context)) {
-                                        Toast.makeText(context, "WIFI 전용 업로드 설정으로 로컬 저장합니다.", Toast.LENGTH_SHORT).show()
-                                        return@launch
-                                    }
+            Toast.makeText(context, "녹화 완료. 업로드 시작...", Toast.LENGTH_SHORT).show()
+            showAnalysisLoading = true
+            analysisProgress = 0f
+            analysisStatusMessage = "영상을 클라우드로 전송 중..."
+            uploader.uploadVideo(
+                fileUri = uri,
+                filename = filename,
+                onUploadProgress = { uploadProgress ->
+                    val cappedUploadProgress = (uploadProgress * 0.2f).coerceIn(0f, 0.2f)
+                    if (analysisProgress < 0.2f) {
+                        analysisProgress = cappedUploadProgress.coerceAtLeast(analysisProgress)
+                    }
+                    analysisStatusMessage = "영상을 클라우드로 전송 중... ${(uploadProgress * 100).toInt()}%"
+                },
+                onComplete = {
+                    Toast.makeText(context, "업로드 성공!", Toast.LENGTH_SHORT).show()
+                    analysisProgress = 0.2f
+                    analysisStatusMessage = "서버에서 AI 분석 중..."
 
-                                    Toast.makeText(context, "업로드 시작...", Toast.LENGTH_SHORT).show()
-                                    uploader.uploadVideo(
-                                        fileUri = uri,
-                                        filename = filename,
-                                        onComplete = { s3Key ->
-                                            Toast.makeText(context, "업로드 완료!", Toast.LENGTH_SHORT).show()
-                                            onRecordingComplete(s3Key)
-                                        },
-                                        onError = { e ->
-                                            Toast.makeText(context, "업로드 실패: ${e.message}", Toast.LENGTH_LONG).show()
-                                            Log.e("TabletRecord", "Upload failed", e)
-                                        }
-                                    )
-                                }
-                            }
-                            isRecording = false
+                    progressRampJob?.cancel()
+                    progressRampJob = scope.launch {
+                        repeat(12) {
+                            delay(1000)
+                            if (analysisProgress >= 0.92f) return@launch
+                            analysisProgress = (analysisProgress + 0.06f).coerceAtMost(0.92f)
                         }
                     }
-            }
+
+                    scope.launch {
+                        uploader.pollAnalysisResult(
+                            userId = userId,
+                            timestamp = timestamp,
+                            onProgress = { msg ->
+                                analysisStatusMessage = msg
+                                analysisProgress = (analysisProgress + 0.03f).coerceAtMost(0.95f)
+                            },
+                            onComplete = { resultS3Key ->
+                                scope.launch {
+                                    try {
+                                        progressRampJob?.cancel()
+
+                                        while (analysisProgress < 1f) {
+                                            analysisProgress = (analysisProgress + 0.04f).coerceAtMost(1f)
+                                            delay(60)
+                                        }
+
+                                        val jsonString = uploader.downloadResultJson(resultS3Key)
+                                        val jsonFileName = uploader.extractResultFileName(resultS3Key)
+                                        val response = Gson().fromJson(jsonString, AnalysisResultResponse::class.java)
+                                        val metadata = FilenameParser.ParsedMetadata(
+                                            userId = userId,
+                                            songId = songIdForDb,
+                                            artist = artist,
+                                            partNumber = partNum
+                                        )
+                                        val jsonPath = File(File(context.filesDir, "analysis_results"), jsonFileName).absolutePath
+                                        val historyEntity = AnalysisMapper.mapToPracticeHistory(
+                                            analysisResult = response,
+                                            metadata = metadata,
+                                            videoPath = uri.toString(),
+                                            fullJsonPath = jsonPath
+                                        )
+
+                                        mainViewModel?.savePracticeResult(historyEntity)
+                                        analysisStatusMessage = "분석 완료!"
+                                        showAnalysisLoading = false
+                                        Toast.makeText(context, "분석 완료!", Toast.LENGTH_SHORT).show()
+                                        onRecordingComplete("$jsonFileName|${uri}")
+                                    } catch (e: Exception) {
+                                        progressRampJob?.cancel()
+                                        showAnalysisLoading = false
+                                        Toast.makeText(context, "결과 처리 실패: ${e.message}", Toast.LENGTH_LONG).show()
+                                        Log.e("PracticeTablet", "결과 처리 실패", e)
+                                    }
+                                }
+                            },
+                            onError = { e ->
+                                progressRampJob?.cancel()
+                                showAnalysisLoading = false
+                                Toast.makeText(context, "분석 실패: ${e.message}", Toast.LENGTH_LONG).show()
+                            }
+                        )
+                    }
+                },
+                onError = { e ->
+                    progressRampJob?.cancel()
+                    showAnalysisLoading = false
+                    Toast.makeText(context, "업로드 실패: ${e.message}", Toast.LENGTH_LONG).show()
+                    Log.e("PracticeTablet", "Upload failed", e)
+                }
+            )
         }
+    }
+
+    fun startRecordingWithCountdown() {
+        val videoCapture = videoCaptureState.value
+        if (videoCapture == null) {
+            Toast.makeText(context, "카메라 준비 중입니다. 잠시 후 다시 시도해 주세요.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        if (isRecording || isCountdownVisible) return
+
+        scope.launch {
+            exoPlayer.seekTo(0)
+            exoPlayer.pause()
+
+            countdownNumber = TabletRecordCountdownSeconds
+            isCountdownVisible = true
+            while (countdownNumber > 0) {
+                delay(1000)
+                countdownNumber--
+            }
+            isCountdownVisible = false
+
+            exoPlayer.seekTo(0)
+            exoPlayer.pause()
+            hasAutoStoppedRecording = false
+
+            val name = "Kpop_Tablet_${System.currentTimeMillis()}.mp4"
+            val contentValues = ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, name)
+                put(MediaStore.MediaColumns.MIME_TYPE, "video/mp4")
+                put(MediaStore.Video.Media.RELATIVE_PATH, "Movies/KpopDancePractice")
+            }
+            val mediaStoreOutputOptions = MediaStoreOutputOptions
+                .Builder(context.contentResolver, MediaStore.Video.Media.EXTERNAL_CONTENT_URI)
+                .setContentValues(contentValues)
+                .build()
+
+            recordingState.value = videoCapture.output
+                .prepareRecording(context, mediaStoreOutputOptions)
+                .apply { if (hasPermissions) withAudioEnabled() }
+                .start(ContextCompat.getMainExecutor(context)) { event ->
+                    when (event) {
+                        is VideoRecordEvent.Start -> {
+                            exoPlayer.seekTo(0)
+                            exoPlayer.play()
+                            isRecording = true
+                        }
+
+                        is VideoRecordEvent.Finalize -> handleRecordingFinalize(event)
+                    }
+                }
+        }
+    }
+
+    val formatTime = { ms: Long ->
+        val totalSeconds = ms / 1000
+        String.format(Locale.getDefault(), "%d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+    val currentTimeStr = formatTime(currentPositionMs)
+    val totalTimeStr = if (totalDurationMs > 0) formatTime(totalDurationMs) else length
+    val sliderPosition = if (totalDurationMs > 0) currentPositionMs.toFloat() / totalDurationMs.toFloat() else 0f
+
+    if (showAnalysisLoading) {
+        AnalysisWaitingScreen(
+            progress = analysisProgress,
+            statusMessage = analysisStatusMessage,
+            onAnalysisComplete = { }
+        )
+        return
     }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0xFF101828))
+            .background(Color.Black)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null
-            ) {
-                areControlsVisible = !areControlsVisible
-            }
+            ) { areControlsVisible = !areControlsVisible }
     ) {
         Row(modifier = Modifier.fillMaxSize()) {
-            // 왼쪽: 댄서 튜토리얼 영상 영역
             Box(
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxHeight()
-                    .background(
-                        Brush.verticalGradient(
-                            listOf(Color(0xFF673AB7).copy(alpha = 0.8f), Color(0xFF3F51B5).copy(alpha = 0.9f))
-                        )
-                    ),
+                    .background(Color.Black),
                 contentAlignment = Alignment.Center
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Box(
-                        modifier = Modifier
-                            .size(100.dp)
-                            .clip(CircleShape)
-                            .background(Color.White.copy(alpha = 0.8f))
-                            .clickable { toggleRecording() }, // 재생 아이콘 클릭 시 녹화 토글
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Icon(
-                            imageVector = if (isRecording) Icons.Default.Stop else Icons.Default.PlayArrow,
-                            contentDescription = "녹화 시작/중지",
-                            modifier = Modifier.size(50.dp),
-                            tint = Color.Black
-                        )
+                AndroidView(
+                    factory = { ctx -> PlayerView(ctx).apply { player = exoPlayer; useController = false } },
+                    modifier = Modifier.fillMaxSize(),
+                    update = { if (it.player != exoPlayer) it.player = exoPlayer }
+                )
+
+                if (!isRecording && !isCountdownVisible) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Box(
+                            modifier = Modifier
+                                .size(96.dp)
+                                .clip(CircleShape)
+                                .background(Color.White.copy(alpha = 0.8f))
+                                .clickable {
+                                    if (exoPlayer.isPlaying) exoPlayer.pause() else exoPlayer.play()
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                imageVector = if (exoPlayer.isPlaying) Icons.Default.MusicNote else Icons.Default.PlayArrow,
+                                contentDescription = "안무 영상 재생",
+                                modifier = Modifier.size(48.dp),
+                                tint = Color.Black.copy(alpha = 0.8f)
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text("댄서 안무 영상", color = Color.White.copy(alpha = 0.65f), fontSize = 16.sp)
                     }
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text("댄서 튜토리얼 영상", color = Color.White.copy(alpha = 0.7f), fontSize = 18.sp)
                 }
             }
 
-            // 오른쪽: 사용자 녹화 화면 영역
             Box(
                 modifier = Modifier
                     .weight(1f)
@@ -256,42 +539,27 @@ fun PracticeScreenTablet(
                     .background(Color.Black)
             ) {
                 if (isPreview) {
-                    Box(
-                        modifier = Modifier.fillMaxSize().background(Color.DarkGray),
-                        contentAlignment = Alignment.Center
-                    ) {
+                    Box(modifier = Modifier.fillMaxSize().background(Color.DarkGray), contentAlignment = Alignment.Center) {
                         Text("카메라 미리보기 (Preview)", color = Color.White)
                     }
                 } else if (hasPermissions) {
                     AndroidView(
-                        factory = { ctx ->
-                            PreviewView(ctx).apply {
-                                implementationMode = PreviewView.ImplementationMode.COMPATIBLE
-                            }
-                        },
+                        factory = { ctx -> PreviewView(ctx).apply { implementationMode = PreviewView.ImplementationMode.COMPATIBLE } },
                         modifier = Modifier.fillMaxSize(),
                         update = { previewView ->
                             val cameraProviderFuture = ProcessCameraProvider.getInstance(context)
                             cameraProviderFuture.addListener({
                                 val cameraProvider = cameraProviderFuture.get()
-                                val preview = androidx.camera.core.Preview.Builder().build().also {
-                                    it.setSurfaceProvider(previewView.surfaceProvider)
-                                }
-                                val recorder = Recorder.Builder()
-                                    .setQualitySelector(QualitySelector.from(Quality.FHD))
-                                    .build()
+                                val preview = Preview.Builder().build().also { it.setSurfaceProvider(previewView.surfaceProvider) }
+                                val qualitySelector = QualitySelector.from(Quality.FHD, FallbackStrategy.lowerQualityOrHigherThan(Quality.FHD))
+                                val recorder = Recorder.Builder().setQualitySelector(qualitySelector).build()
                                 val videoCapture = VideoCapture.withOutput(recorder)
                                 videoCaptureState.value = videoCapture
-
-                                val cameraSelector = CameraSelector.Builder()
-                                    .requireLensFacing(lensFacing)
-                                    .build()
+                                val cameraSelector = CameraSelector.Builder().requireLensFacing(lensFacing).build()
 
                                 try {
                                     cameraProvider.unbindAll()
-                                    cameraProvider.bindToLifecycle(
-                                        lifecycleOwner, cameraSelector, preview, videoCapture
-                                    )
+                                    cameraProvider.bindToLifecycle(lifecycleOwner, cameraSelector, preview, videoCapture)
                                 } catch (e: Exception) {
                                     Log.e("PracticeTablet", "Camera binding failed", e)
                                 }
@@ -299,30 +567,53 @@ fun PracticeScreenTablet(
                         }
                     )
                 } else {
-                    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("카메라 권한이 필요합니다.", color = Color.White)
+                    Column(
+                        modifier = Modifier.align(Alignment.Center),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text("카메라 및 오디오 권한이 필요합니다.", color = Color.White)
+                        Button(onClick = { launcher.launch(arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)) }) {
+                            Text("권한 허용하기")
+                        }
                     }
                 }
 
-                // 녹화 시간 표시
-                if (isRecording) {
-                    Row(
-                        modifier = Modifier.align(Alignment.TopCenter).padding(top = 24.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Box(modifier = Modifier.size(12.dp).clip(CircleShape).background(Color.Red))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = String.format(Locale.getDefault(), "%02d:%02d", recordingTime / 60, recordingTime % 60),
-                            color = Color.White,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                }
+                Text(
+                    text = "내 녹화 화면",
+                    modifier = Modifier.align(Alignment.TopStart).padding(20.dp),
+                    color = Color.White.copy(alpha = 0.75f),
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
             }
         }
 
-        // 상단 컨트롤 바
+        if (isCountdownVisible) {
+            Text(
+                text = countdownNumber.toString(),
+                color = Color.White,
+                fontSize = 112.sp,
+                fontWeight = FontWeight.ExtraBold,
+                modifier = Modifier.align(Alignment.Center)
+            )
+        }
+
+        if (isRecording) {
+            Row(
+                modifier = Modifier.align(Alignment.TopCenter).statusBarsPadding().padding(top = 24.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(modifier = Modifier.size(12.dp).clip(CircleShape).background(Color.Red))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = String.format(Locale.getDefault(), "%02d:%02d", recordingTime / 60, recordingTime % 60),
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+
         AnimatedVisibility(
             visible = areControlsVisible,
             modifier = Modifier.align(Alignment.TopCenter),
@@ -333,7 +624,7 @@ fun PracticeScreenTablet(
                 modifier = Modifier
                     .fillMaxWidth()
                     .statusBarsPadding()
-                    .padding(16.dp),
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -341,15 +632,20 @@ fun PracticeScreenTablet(
                     Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = Color.White)
                 }
 
-                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    RoundIconButton(icon = Icons.AutoMirrored.Filled.VolumeUp, onClick = {})
-                    RoundIconButton(icon = Icons.Default.Refresh, onClick = { lensFacing = if (lensFacing == CameraSelector.LENS_FACING_FRONT) CameraSelector.LENS_FACING_BACK else CameraSelector.LENS_FACING_FRONT })
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                    RoundIconButton(
+                        icon = if (isMuted) Icons.Default.VolumeOff else Icons.Default.VolumeUp,
+                        onClick = { isMuted = !isMuted }
+                    )
+                    RoundIconButton(
+                        icon = Icons.Default.Refresh,
+                        onClick = { lensFacing = if (lensFacing == CameraSelector.LENS_FACING_FRONT) CameraSelector.LENS_FACING_BACK else CameraSelector.LENS_FACING_FRONT }
+                    )
                     RoundIconButton(icon = Icons.Default.Settings, onClick = onSettingsClick)
                 }
             }
         }
 
-        // 하단 제어판
         AnimatedVisibility(
             visible = areControlsVisible,
             modifier = Modifier.align(Alignment.BottomCenter),
@@ -359,47 +655,86 @@ fun PracticeScreenTablet(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color.Black.copy(alpha = 0.6f))
+                    .background(Color.Black.copy(alpha = 0.65f))
                     .navigationBarsPadding()
-                    .padding(24.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                    .padding(horizontal = 24.dp, vertical = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(14.dp)
             ) {
                 SongInfoBar(title = songTitle, artistPart = artistPart, difficulty = difficulty)
-                
-//                PlaybackSlider(
-//                    currentPosition = currentPosition,
-//                    totalTime = length,
-//                    //onPositionChange = { currentPosition = it }
-//                )
+                PlaybackSlider(
+                    currentPosition = sliderPosition,
+                    currentTime = currentTimeStr,
+                    totalTime = totalTimeStr,
+                    onPositionChange = { newPosition ->
+                        val targetMs = (newPosition * totalDurationMs).toLong()
+                        exoPlayer.seekTo(targetMs)
+                    }
+                )
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    SpeedControlRow(
-                        selectedSpeed = selectedSpeed,
-                        onSpeedSelected = { selectedSpeed = it }
-                    )
+                    Box(modifier = Modifier.weight(1f)) {
+                        SpeedControlRow(selectedSpeed = selectedSpeed, onSpeedSelected = { selectedSpeed = it })
+                    }
 
-                    // 하단 녹화 버튼
-                    val buttonPadding by animateDpAsState(if (isRecording) 12.dp else 4.dp, label = "")
+                    Spacer(modifier = Modifier.width(24.dp))
+
+                    Button(
+                        onClick = {
+                            if (isRecording) {
+                                recordingState.value?.stop()
+                                recordingState.value = null
+                                isRecording = false
+                            } else {
+                                startRecordingWithCountdown()
+                            }
+                        },
+                        colors = ButtonDefaults.buttonColors(containerColor = Color.White, contentColor = Color.Black)
+                    ) {
+                        Icon(
+                            imageVector = if (isRecording) Icons.Default.Stop else Icons.Default.CameraAlt,
+                            contentDescription = null
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(if (isRecording) "녹화 중지" else "3초 후 녹화")
+                    }
+
+                    Spacer(modifier = Modifier.width(18.dp))
+
+                    val buttonPadding by animateDpAsState(if (isRecording) 14.dp else 5.dp, label = "tabletRecordButtonPadding")
                     Box(
                         modifier = Modifier
-                            .size(64.dp)
+                            .size(68.dp)
                             .border(3.dp, Color.White, CircleShape)
                             .padding(buttonPadding)
                             .clip(if (isRecording) RoundedCornerShape(8.dp) else CircleShape)
                             .background(Color.Red)
-                            .clickable { toggleRecording() }
+                            .clickable {
+                                if (isRecording) {
+                                    recordingState.value?.stop()
+                                    recordingState.value = null
+                                    isRecording = false
+                                } else {
+                                    startRecordingWithCountdown()
+                                }
+                            }
                     )
                 }
+
+                Text(
+                    text = "녹화 버튼을 누르면 3초 카운트다운 후 왼쪽 안무 영상이 처음부터 재생되고 오른쪽 카메라 녹화가 시작됩니다.",
+                    color = Color.White.copy(alpha = 0.72f),
+                    style = MaterialTheme.typography.bodySmall
+                )
             }
         }
     }
 }
 
-@Preview(showBackground = true, device = "spec:width=1280dp,height=800dp,orientation=landscape")
+@ComposePreview(showBackground = true, device = "spec:width=1280dp,height=800dp,orientation=landscape")
 @Composable
 fun PracticeScreenTabletPreview() {
     KpopDancePracticeAITheme {


### PR DESCRIPTION
### Motivation
- Provide a tablet-optimized Practice screen that shows the expert choreography video and a camera recording view side-by-side so users can follow and record on a large display.
- Reuse the existing mobile recording/upload/analysis flow so tablet recordings are uploaded and processed the same way as mobile recordings.
- Ensure a deterministic UX where pressing record triggers a 3-second countdown and then restarts the expert video and recording simultaneously.

### Description
- Reworked `PracticeScreenTablet` into a two-pane layout: left pane renders the expert choreography with `ExoPlayer` and right pane hosts `PreviewView` + `CameraX` recording pipeline, mirroring the mobile `RecordScreen` behavior.
- Added synchronized recording logic: pressing the tablet record button runs a fixed 3-second countdown (`TabletRecordCountdownSeconds = 3`), seeks the expert `ExoPlayer` to start, then starts CameraX recording and begins playback when `VideoRecordEvent.Start` is received.
- Implemented recording finalize handling that reuses `PresignedUrlUploader` upload flow and analysis polling, downloads result JSON, maps it to history via `AnalysisMapper`, and calls `onRecordingComplete` with a combined result string of the form `<jsonFileName>|<videoUri>`.
- Updated navigation in `AppNavigation.kt` to pass `songId`, `videoUrl`, `mainViewModel` and `onNavigateHome` into `PracticeScreenTablet`, and to decode the `onRecordingComplete` return value into JSON filename and video URI for the `practiceResult` route.

### Testing
- Ran `git diff --check` to validate formatting and found no issues (success).
- Attempted to compile Kotlin with `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 gradle :app:compileDebugKotlin` but the build failed because the Android Gradle plugin `9.1.0` could not be resolved from the environment repositories (blocked).
- Attempted `./gradlew :app:compileDebugKotlin` but the Gradle wrapper failed to download the distribution due to an outbound proxy returning `HTTP/1.1 403 Forbidden` (blocked).
- Changes committed with message `Implement tablet split practice recording` and include updates to `PracticeScreenTablet.kt` and `AppNavigation.kt`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef5cf4ae08320a32606cc9519d67c)