### PR TITLE
Add badge selection, owned lightstick support and DB schema bump to v6

### DIFF
--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/RealDataSource.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/RealDataSource.kt
@@ -21,18 +21,18 @@ object RealDataSource {
     private const val APP_PACKAGE_NAME = "com.example.kpopdancepracticeai"
 
     private fun expertVideo(fileName: String): String = "$EXPERT_VIDEO_BASE_PATH$fileName"
-    private fun drawableCover(fileName: String): String =
+    private fun drawableResource(fileName: String): String =
         "android.resource://$APP_PACKAGE_NAME/drawable/$fileName"
 
     private fun coverForSongTitle(titleEn: String): String = when (titleEn.lowercase()) {
-        "eleven" -> drawableCover("cover_eleven")
-        "o.o" -> drawableCover("cover_oo")
-        "wannabe" -> drawableCover("cover_wannabe")
-        "loco" -> drawableCover("cover_loco")
-        "love dive" -> drawableCover("cover_lovedive")
-        "stay this way" -> drawableCover("cover_staythisway")
-        "sneakers" -> drawableCover("cover_sneakers")
-        else -> drawableCover("cover_eleven")
+        "eleven" -> drawableResource("cover_eleven")
+        "o.o" -> drawableResource("cover_oo")
+        "wannabe" -> drawableResource("cover_wannabe")
+        "loco" -> drawableResource("cover_loco")
+        "love dive" -> drawableResource("cover_lovedive")
+        "stay this way" -> drawableResource("cover_staythisway")
+        "sneakers" -> drawableResource("cover_sneakers")
+        else -> drawableResource("cover_eleven")
     }
 
     val songDetailMetadataByTitleKr = mapOf(
@@ -332,11 +332,14 @@ object RealDataSource {
         )
     )
 
+    // 응원봉 PNG 파일은 app/src/main/res/drawable/ 아래에
+    // lightstick_itzy.png, lightstick_ive.png, lightstick_nmixx.png,
+    // lightstick_fromis9.png, lightstick_straykids.png 이름으로 저장합니다.
     val getRealLightSticks = listOf(
         LightStick(
             id = "icon_itzy_complete_50",
             name = "ITZY 응원봉",
-            localImagePath = "",
+            localImagePath = drawableResource("lightstick_itzy"),
             artist = "ITZY",
             isOwned = false,
             obtainedAt = null
@@ -344,7 +347,7 @@ object RealDataSource {
         LightStick(
             id = "icon_ive_complete_50",
             name = "IVE 응원봉",
-            localImagePath = "",
+            localImagePath = drawableResource("lightstick_ive"),
             artist = "IVE",
             isOwned = false,
             obtainedAt = null
@@ -352,7 +355,7 @@ object RealDataSource {
         LightStick(
             id = "icon_nmixx_complete_50",
             name = "NMIXX 응원봉",
-            localImagePath = "",
+            localImagePath = drawableResource("lightstick_nmixx"),
             artist = "NMIXX",
             isOwned = false,
             obtainedAt = null
@@ -360,7 +363,7 @@ object RealDataSource {
         LightStick(
             id = "icon_fromis9_complete_50",
             name = "프로미스나인 응원봉",
-            localImagePath = "",
+            localImagePath = drawableResource("lightstick_fromis9"),
             artist = "프로미스나인",
             isOwned = false,
             obtainedAt = null
@@ -368,7 +371,7 @@ object RealDataSource {
         LightStick(
             id = "icon_straykids_complete_50",
             name = "스트레이키즈 응원봉",
-            localImagePath = "",
+            localImagePath = drawableResource("lightstick_straykids"),
             artist = "스트레이키즈",
             isOwned = false,
             obtainedAt = null

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/dao/AchievementDao.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/dao/AchievementDao.kt
@@ -48,8 +48,11 @@ interface AchievementDao {
     suspend fun getAchievementByCode(code: String): Achievement?
 
     // [수정됨] 이제 Badge.kt에 user_uuid가 추가되었으므로 오류 없이 정상 작동합니다!
-    @Query("SELECT * FROM badges WHERE user_uuid = :userId AND isUnlocked = 1")
+    @Query("SELECT * FROM badges WHERE user_uuid = :userId AND isUnlocked = 1 ORDER BY is_selected DESC, obtainedAt DESC, name ASC")
     fun getUserBadges(userId: String): Flow<List<Badge>>
+
+    @Query("SELECT * FROM badges WHERE user_uuid = :userId AND isUnlocked = 1 AND is_selected = 1 LIMIT 1")
+    fun getSelectedBadge(userId: String): Flow<Badge?>
 
     // 초기 데이터 세팅용: 업적 메타 데이터 삽입
     @Insert(onConflict = OnConflictStrategy.IGNORE)
@@ -71,8 +74,17 @@ interface AchievementDao {
     @Query("UPDATE user_achievement_progress SET current_step = :step, is_completed = :completed, achieved_date = :date WHERE user_uuid = :userId AND achievement_code = :code")
     suspend fun updateProgress(userId: String, code: String, step: Int, completed: Boolean, date: String?)
 
-    @Query("UPDATE badges SET isUnlocked = 1, obtainedAt = :obtainedAt WHERE user_uuid = :userId AND id = :badgeId AND isUnlocked = 0")
+    @Query("UPDATE badges SET isUnlocked = 1, obtainedAt = :obtainedAt, is_selected = CASE WHEN (SELECT COUNT(*) FROM badges WHERE user_uuid = :userId AND isUnlocked = 1) = 0 THEN 1 ELSE is_selected END WHERE user_uuid = :userId AND id = :badgeId AND isUnlocked = 0")
     suspend fun unlockBadge(userId: String, badgeId: String, obtainedAt: Long): Int
+
+    @Query("UPDATE badges SET is_selected = CASE WHEN id = :badgeId THEN 1 ELSE 0 END WHERE user_uuid = :userId AND isUnlocked = 1")
+    suspend fun selectBadge(userId: String, badgeId: String): Int
+
+    @Query("UPDATE light_sticks SET localImage_path = :localImagePath WHERE id = :lightStickId")
+    suspend fun updateLightStickImagePath(lightStickId: String, localImagePath: String): Int
+
+    @Query("SELECT * FROM light_sticks WHERE is_owned = 1 ORDER BY obtained_at DESC, name ASC")
+    fun getOwnedLightSticks(): Flow<List<LightStick>>
 
     @Query("UPDATE light_sticks SET is_owned = 1, obtained_at = :obtainedAt WHERE id = :lightStickId AND is_owned = 0")
     suspend fun unlockLightStick(lightStickId: String, obtainedAt: Long): Int

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/database/AppDatabase.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/database/AppDatabase.kt
@@ -25,7 +25,7 @@ import com.example.kpopdancepracticeai.data.entity.*
         Badge::class,
         UserAchievementProgress::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/entity/Badge.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/entity/Badge.kt
@@ -30,5 +30,8 @@ data class Badge(
     val isUnlocked: Boolean = false,
 
     @ColumnInfo(name = "obtainedAt")
-    val obtainedAt: Long? = null
+    val obtainedAt: Long? = null,
+
+    @ColumnInfo(name = "is_selected")
+    val isSelected: Boolean = false
 )

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/repository/AppRepository.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/data/repository/AppRepository.kt
@@ -22,6 +22,7 @@ class AppRepository(
     private val achievementDao: AchievementDao,
     private val userChoreoStatsDao: UserChoreoStatsDao
 ) {
+
     // 앱이 메모리에 올라와서 실행되는 순간을 기준 시간으로 바로 잡습니다.
     private var sessionStartTime: Long = System.currentTimeMillis()
 
@@ -105,6 +106,7 @@ class AppRepository(
         // 3. 초기 업적/보상 메타데이터 세팅
         achievementDao.insertAchievements(RealDataSource.getRealAchievements)
         achievementDao.insertLightSticks(RealDataSource.getRealLightSticks)
+        refreshLightStickDrawablePaths()
 
         // 4. 사용자별 업적 진행도 초기화
         // 기존 스키마에서는 progress_id(autoGenerate)가 PK라 동일 사용자/업적코드라도 중복 삽입될 수 있으므로,
@@ -144,6 +146,18 @@ class AppRepository(
     // --- Achievements & Badges ---
     fun getUserAchievements(userId: String): Flow<List<UserAchievementProgress>> = achievementDao.getUserAchievementProgress(userId)
     fun getUserBadges(userId: String): Flow<List<Badge>> = achievementDao.getUserBadges(userId)
+    fun getSelectedBadge(userId: String): Flow<Badge?> = achievementDao.getSelectedBadge(userId)
+    fun getOwnedLightSticks(): Flow<List<LightStick>> = achievementDao.getOwnedLightSticks()
+
+    suspend fun selectBadge(userId: String, badgeId: String) {
+        achievementDao.selectBadge(userId, badgeId)
+    }
+
+    private suspend fun refreshLightStickDrawablePaths() {
+        RealDataSource.getRealLightSticks.forEach { lightStick ->
+            achievementDao.updateLightStickImagePath(lightStick.id, lightStick.localImagePath)
+        }
+    }
 
     // --- Song ---
     val allSongs: Flow<List<Song>> = songDao.getAllSongs()

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/ProfileScreen.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/ui/ProfileScreen.kt
@@ -36,11 +36,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -49,6 +51,7 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.example.kpopdancepracticeai.viewmodel.AchievementUiModel
 import com.example.kpopdancepracticeai.viewmodel.BadgeUiModel
+import com.example.kpopdancepracticeai.viewmodel.LightStickUiModel
 import com.example.kpopdancepracticeai.viewmodel.MainViewModel
 import com.example.kpopdancepracticeai.viewmodel.TopPracticedChoreoUiModel
 import com.example.kpopdancepracticeai.ui.theme.*
@@ -89,6 +92,8 @@ fun ProfileScreen(
     val levelInfo by viewModel.userLevelInfo.collectAsState()
     val achievements by viewModel.achievementProgress.collectAsState()
     val badges by viewModel.userBadges.collectAsState()
+    val selectedBadge by viewModel.selectedBadge.collectAsState()
+    val ownedLightSticks by viewModel.ownedLightSticks.collectAsState()
     val topPracticedChoreos by viewModel.topPracticedChoreos.collectAsState()
 
     val context = LocalContext.current
@@ -119,6 +124,8 @@ fun ProfileScreen(
                 userProfile = userProfile,
                 userStats = userStats,
                 levelInfo = levelInfo,
+                selectedBadge = selectedBadge,
+                representativeLightStick = ownedLightSticks.firstOrNull(),
                 onDetailClick = onNavigateToAnalysis
             )
         }
@@ -130,6 +137,8 @@ fun ProfileScreen(
                 achievements = achievements,
                 badges = badges,
                 topPracticedChoreos = topPracticedChoreos,
+                ownedLightSticks = ownedLightSticks,
+                onBadgeSelected = viewModel::selectBadge,
                 onNavigateToProfileEdit = onNavigateToProfileEdit,
                 onNavigateToPracticeSettings = onNavigateToPracticeSettings,
                 onNavigateToNotificationSettings = onNavigateToNotificationSettings,
@@ -152,6 +161,8 @@ private fun ProfileTabContent(
     achievements: List<AchievementUiModel>,
     badges: List<BadgeUiModel>,
     topPracticedChoreos: List<TopPracticedChoreoUiModel>,
+    ownedLightSticks: List<LightStickUiModel>,
+    onBadgeSelected: (String) -> Unit,
     onNavigateToProfileEdit: () -> Unit,
     onNavigateToPracticeSettings: () -> Unit,
     onNavigateToNotificationSettings: () -> Unit,
@@ -220,8 +231,14 @@ private fun ProfileTabContent(
                             modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp)
                         )
                     }
+                    AnimatedTabEntry(index = 1, animationSpec = animationSpec, replayKey = tab) {
+                        BadgeSelectionCard(badges = badges, onBadgeSelected = onBadgeSelected)
+                    }
+                    AnimatedTabEntry(index = 2, animationSpec = animationSpec, replayKey = tab) {
+                        OwnedLightStickCard(lightSticks = ownedLightSticks)
+                    }
                     if (achievements.isEmpty()) {
-                        AnimatedTabEntry(index = 1, animationSpec = animationSpec, replayKey = tab) {
+                        AnimatedTabEntry(index = 3, animationSpec = animationSpec, replayKey = tab) {
                             Text(
                                 "아직 진행중인 업적이 없습니다.",
                                 modifier = Modifier.fillMaxWidth().padding(20.dp),
@@ -231,7 +248,7 @@ private fun ProfileTabContent(
                         }
                     } else {
                         achievements.forEachIndexed { index, item ->
-                            AnimatedTabEntry(index = index + 1, animationSpec = animationSpec, replayKey = tab) {
+                            AnimatedTabEntry(index = index + 3, animationSpec = animationSpec, replayKey = tab) {
                                 AchievementCard(
                                     title = item.title,
                                     description = item.description,
@@ -312,6 +329,8 @@ fun ProfileHeaderCard(
     userProfile: com.example.kpopdancepracticeai.data.entity.User?,
     userStats: com.example.kpopdancepracticeai.data.entity.UserStats?,
     levelInfo: Pair<Int, Pair<Long, Long>>,
+    selectedBadge: BadgeUiModel?,
+    representativeLightStick: LightStickUiModel?,
     onDetailClick: () -> Unit
 ) {
     Surface(
@@ -358,6 +377,27 @@ fun ProfileHeaderCard(
                             style = MaterialTheme.typography.headlineSmall,
                             fontWeight = FontWeight.Bold
                         )
+                        if (selectedBadge != null || representativeLightStick != null) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                selectedBadge?.let { badge ->
+                                    SparklingBadgeText(text = badge.name)
+                                }
+                                representativeLightStick?.let { lightStick ->
+                                    AsyncImage(
+                                        model = lightStick.localImagePath,
+                                        contentDescription = lightStick.name,
+                                        modifier = Modifier
+                                            .size(24.dp)
+                                            .clip(CircleShape)
+                                            .border(1.dp, Color(0xFFFFD54F), CircleShape),
+                                        contentScale = ContentScale.Crop
+                                    )
+                                }
+                            }
+                        }
                     }
                     CustomShadowButton("상세 통계 보기", onDetailClick, 92.dp, 35.dp, 11.sp)
                 }
@@ -391,6 +431,21 @@ fun ProfileHeaderCard(
             }
         }
     }
+}
+
+@Composable
+private fun SparklingBadgeText(text: String) {
+    Text(
+        text = "✦ $text ✦",
+        style = MaterialTheme.typography.labelLarge.copy(
+            brush = Brush.linearGradient(
+                colors = listOf(Color(0xFFFFD54F), Color(0xFFFF6EC7), Color(0xFF7C4DFF))
+            ),
+            fontWeight = FontWeight.ExtraBold
+        ),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis
+    )
 }
 
 @Composable
@@ -615,6 +670,71 @@ fun AcquiredBadgesCard(badges: List<BadgeUiModel>) {
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun BadgeSelectionCard(badges: List<BadgeUiModel>, onBadgeSelected: (String) -> Unit) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        shadowElevation = 4.dp
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("대표 배지 선택", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            if (badges.isEmpty()) {
+                Text("획득한 배지가 없습니다. 그룹별 첫 파트를 완료하면 배지를 얻을 수 있어요.", style = MaterialTheme.typography.bodyMedium, color = Color.Gray)
+            } else {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    badges.forEach { badge ->
+                        BadgeChip(
+                            text = if (badge.isSelected) "✓ ${badge.name}" else badge.name,
+                            color = badge.color,
+                            modifier = Modifier.clickable { onBadgeSelected(badge.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun OwnedLightStickCard(lightSticks: List<LightStickUiModel>) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = Color.White,
+        shadowElevation = 4.dp
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("획득한 아이콘", style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+            if (lightSticks.isEmpty()) {
+                Text("아직 획득한 아이콘이 없습니다. 그룹별 50회 완료 업적에 도전해보세요.", style = MaterialTheme.typography.bodyMedium, color = Color.Gray)
+            } else {
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    lightSticks.forEach { lightStick ->
+                        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.width(72.dp)) {
+                            AsyncImage(
+                                model = lightStick.localImagePath,
+                                contentDescription = lightStick.name,
+                                modifier = Modifier.size(56.dp).clip(CircleShape).border(1.dp, BorderLight, CircleShape),
+                                contentScale = ContentScale.Crop
+                            )
+                            Text(lightStick.artist, style = MaterialTheme.typography.labelSmall, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 @Composable
 fun SettingsContent(
     onNavigateToProfileEdit: () -> Unit,
@@ -742,11 +862,11 @@ fun AchievementCard(
 }
 
 @Composable
-fun BadgeChip(text: String, color: Color) {
+fun BadgeChip(text: String, color: Color, modifier: Modifier = Modifier) {
     Surface(
         color = color,
         shape = RoundedCornerShape(12.dp),
-        modifier = Modifier.padding(2.dp)
+        modifier = modifier.padding(2.dp)
     ) {
         Text(
             text = text,

--- a/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/viewmodel/MainViewModel.kt
+++ b/kpop-android-app/app/src/main/java/com/example/kpopdancepracticeai/viewmodel/MainViewModel.kt
@@ -26,8 +26,17 @@ data class AchievementUiModel(
 
 // UI용 배지 데이터 클래스
 data class BadgeUiModel(
+    val id: String,
     val name: String,
-    val color: Color
+    val color: Color,
+    val isSelected: Boolean
+)
+
+data class LightStickUiModel(
+    val id: String,
+    val name: String,
+    val artist: String,
+    val localImagePath: String
 )
 
 
@@ -116,6 +125,12 @@ class MainViewModel(private val repository: AppRepository) : ViewModel() {
 
     private val _userBadges = MutableStateFlow<List<BadgeUiModel>>(emptyList())
     val userBadges: StateFlow<List<BadgeUiModel>> = _userBadges.asStateFlow()
+
+    private val _selectedBadge = MutableStateFlow<BadgeUiModel?>(null)
+    val selectedBadge: StateFlow<BadgeUiModel?> = _selectedBadge.asStateFlow()
+
+    private val _ownedLightSticks = MutableStateFlow<List<LightStickUiModel>>(emptyList())
+    val ownedLightSticks: StateFlow<List<LightStickUiModel>> = _ownedLightSticks.asStateFlow()
 
     private val achievementMetaByCode = RealDataSource.getRealAchievements.associateBy { it.id }
 
@@ -223,13 +238,33 @@ class MainViewModel(private val repository: AppRepository) : ViewModel() {
                 launch {
                     repository.getUserBadges(userId).collect { list ->
                         _userBadges.value = list.map { badge ->
-                            val color = when {
-                                badge.name.contains("마스터") -> Color(0xFFEBEBFF)
-                                badge.name.contains("팬") -> Color(0xFFD6F5FF)
-                                badge.name.contains("전문가") -> Color(0xFFFFD6EB)
-                                else -> Color(0xFFD9FFE5)
-                            }
-                            BadgeUiModel(badge.name, color)
+                            BadgeUiModel(badge.id, badge.name, badgeColorForName(badge.name), badge.isSelected)
+                        }
+                    }
+                }
+
+                launch {
+                    repository.getSelectedBadge(userId).collect { badge ->
+                        _selectedBadge.value = badge?.let {
+                            BadgeUiModel(
+                                id = it.id,
+                                name = it.name,
+                                color = badgeColorForName(it.name),
+                                isSelected = true
+                            )
+                        }
+                    }
+                }
+
+                launch {
+                    repository.getOwnedLightSticks().collect { lightSticks ->
+                        _ownedLightSticks.value = lightSticks.map {
+                            LightStickUiModel(
+                                id = it.id,
+                                name = it.name,
+                                artist = it.artist,
+                                localImagePath = it.localImagePath
+                            )
                         }
                     }
                 }
@@ -242,6 +277,20 @@ class MainViewModel(private val repository: AppRepository) : ViewModel() {
                 _isSyncing.value = false
             }
         }
+    }
+
+    fun selectBadge(badgeId: String) {
+        val userId = currentUserId ?: return
+        viewModelScope.launch {
+            repository.selectBadge(userId, badgeId)
+        }
+    }
+
+    private fun badgeColorForName(name: String): Color = when {
+        name.contains("마스터") -> Color(0xFFEBEBFF)
+        name.contains("팬") -> Color(0xFFD6F5FF)
+        name.contains("전문가") -> Color(0xFFFFD6EB)
+        else -> Color(0xFFD9FFE5)
     }
 
     fun registerUser(userId: String, email: String, passwordHash: String, name: String, birthDate: String) {


### PR DESCRIPTION
### Motivation

- Enable users to select a representative badge and show owned lightstick icons in the profile UI.  
- Persist badge selection and lightstick image paths in the local DB and ensure newly inserted lightstick metadata has drawable resource paths.  
- Update local database schema to support selection state for badges and additional queries for onboarding and UI features.

### Description

- Added `is_selected` to the `Badge` entity and bumped Room schema `version` from `5` to `6`.  
- Extended `AchievementDao` with ordered `getUserBadges`, `getSelectedBadge`, `selectBadge`, `updateLightStickImagePath`, and `getOwnedLightSticks`, and adjusted `unlockBadge` to auto-select the first unlocked badge.  
- Updated `RealDataSource` to expose drawable resource URIs via `drawableResource(...)` and populated `localImagePath` for real lightsticks; added inline comment listing expected drawable files.  
- Added repository methods `getSelectedBadge`, `getOwnedLightSticks`, `selectBadge`, and a `refreshLightStickDrawablePaths()` call during initial data fetch to persist drawable paths into DB.  
- ViewModel additions: `BadgeUiModel` now includes `id` and `isSelected`, added `LightStickUiModel`, flows for `selectedBadge` and `ownedLightSticks`, a `selectBadge` action, and mapping logic for the new DAO results.  
- UI changes in `ProfileScreen`: show selected badge and representative lightstick in the header, added `BadgeSelectionCard` and `OwnedLightStickCard`, a sparkling badge text composable, and small styling adjustments; changed `BadgeChip` to accept a `Modifier` for click handling.

### Testing

- Built the app with `./gradlew assembleDebug` locally and the build completed successfully.  
- Ran unit tests with `./gradlew test` and they passed in the local environment.  
- Verified profile sync path that seeds metadata triggers `refreshLightStickDrawablePaths()` to store drawable URIs into the `light_sticks` table during data initialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff08de4aa48320be59e2c91a27dba3)